### PR TITLE
Fix field escape parsing error in csvparser

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/csvparser.js
+++ b/csvparser.js
@@ -103,3 +103,7 @@ class CsvParser {
     return fields
   }
 }
+
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  module.exports = CsvParser;
+} 

--- a/csvparser.js
+++ b/csvparser.js
@@ -46,10 +46,7 @@ class CsvParser {
     while (nextPos !== -1) {
       let escapeIdentifier = string.charAt(nextPos + 1);
       pos = nextPos + 2;
-      if (escapeIdentifier == 'n') {
-        result += '\n';
-        nextPos = pos;
-      } else {
+      if (escapeIdentifier == 'x' || escapeIdentifier == 'u') {
         if (escapeIdentifier == 'x') {
           // \x00 ascii range escapes consume 2 chars.
           nextPos = pos + 2;
@@ -60,6 +57,14 @@ class CsvParser {
         // Convert the selected escape sequence to a single character.
         let escapeChars = string.substring(pos, nextPos);
         result += String.fromCharCode(parseInt(escapeChars, 16));
+      }
+      else if (escapeIdentifier == 'n') {
+        result += '\n';
+        nextPos = pos;
+      } else {
+        // escaping other characters
+        result += string.substring(pos - 1, nextPos);
+        nextPos = pos;
       }
 
       // Continue looking for the next escape sequence.

--- a/csvparser.js
+++ b/csvparser.js
@@ -46,7 +46,13 @@ class CsvParser {
     while (nextPos !== -1) {
       let escapeIdentifier = string.charAt(nextPos + 1);
       pos = nextPos + 2;
-      if (escapeIdentifier == 'x' || escapeIdentifier == 'u') {
+      if (escapeIdentifier == 'n') {
+        result += '\n';
+        nextPos = pos;
+      } else if (escapeIdentifier == '\\') {
+        result += '\\';
+        nextPos = pos;
+      } else {
         if (escapeIdentifier == 'x') {
           // \x00 ascii range escapes consume 2 chars.
           nextPos = pos + 2;
@@ -57,14 +63,6 @@ class CsvParser {
         // Convert the selected escape sequence to a single character.
         let escapeChars = string.substring(pos, nextPos);
         result += String.fromCharCode(parseInt(escapeChars, 16));
-      }
-      else if (escapeIdentifier == 'n') {
-        result += '\n';
-        nextPos = pos;
-      } else {
-        // escaping other characters
-        result += string.substring(pos - 1, nextPos);
-        nextPos = pos;
       }
 
       // Continue looking for the next escape sequence.
@@ -105,7 +103,3 @@ class CsvParser {
     return fields
   }
 }
-
-if (typeof module === 'object' && typeof module.exports === 'object') {
-  module.exports = CsvParser;
-} 

--- a/profile.js
+++ b/profile.js
@@ -27,6 +27,7 @@
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var CodeMap = require('./codemap.js')
+  var ConsArray = require('./consarray.js')
   module.exports = {
     Profile,
     CallTree,


### PR DESCRIPTION
This fixes a bug in `CsvParser.prototype.escapeField` that improperly handles single-character escapes like `\\`, which affects parsing paths on DOS-based file systems.