### PR TITLE
Update source from V8 repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Core JavaScript modules supporting v8 tools.
 
 Files pulled from the `./tools` folder of the [v8 repo](https://github.com/v8/v8) to support
 tools like the _ic-explorer_ and _map-processor_. 
+
+Last update from V8 was from [4/27/2020](https://github.com/v8/v8/tree/abfdb819ced84d76595083a5c278ad2561d3f516).

--- a/SourceMap.js
+++ b/SourceMap.js
@@ -325,8 +325,19 @@ WebInspector.SourceMap.prototype = {
 
         // Fix the sign.
         var negative = result & 1;
-        result >>= 1;
-        return negative ? -result : result;
+        // Use unsigned right shift, so that the 32nd bit is properly shifted
+        // to the 31st, and the 32nd becomes unset.
+        result >>>= 1;
+        if (negate) {
+          // We need to OR 0x80000000 here to ensure the 32nd bit (the sign bit
+          // in a 32bit int) is always set for negative numbers. If `result`
+          // were 1, (meaning `negate` is true and all other bits were zeros),
+          // `result` would now be 0. But -0 doesn't flip the 32nd bit as
+          // intended. All other numbers will successfully set the 32nd bit
+          // without issue, so doing this is a noop for them.
+          return -result | 0x80000000;
+        }
+        return result;
     },
 
     _VLQ_BASE_SHIFT: 5,

--- a/codemap.js
+++ b/codemap.js
@@ -140,7 +140,7 @@ CodeMap.prototype.addStaticCode = function(
 CodeMap.prototype.markPages_ = function(start, end) {
   for (var addr = start; addr <= end;
        addr += CodeMap.PAGE_SIZE) {
-    this.pages_[addr >>> CodeMap.PAGE_ALIGNMENT] = 1;
+    this.pages_[(addr / CodeMap.PAGE_SIZE)|0] = 1;
   }
 };
 
@@ -187,7 +187,7 @@ CodeMap.prototype.findInTree_ = function(tree, addr) {
  * @param {number} addr Address.
  */
 CodeMap.prototype.findAddress = function(addr) {
-  var pageAddr = addr >>> CodeMap.PAGE_ALIGNMENT;
+  var pageAddr = (addr / CodeMap.PAGE_SIZE)|0;
   if (pageAddr in this.pages_) {
     // Static code entries can contain "holes" of unnamed code.
     // In this case, the whole library is assigned to this address.

--- a/csvparser.js
+++ b/csvparser.js
@@ -46,11 +46,14 @@ class CsvParser {
     while (nextPos !== -1) {
       let escapeIdentifier = string.charAt(nextPos + 1);
       pos = nextPos + 2;
-      if (escapeIdentifier == 'n') {
+      if (escapeIdentifier === 'n') {
         result += '\n';
         nextPos = pos;
+      } else if (escapeIdentifier === '\\') {
+        result += '\\';
+        nextPos = pos;
       } else {
-        if (escapeIdentifier == 'x') {
+        if (escapeIdentifier === 'x') {
           // \x00 ascii range escapes consume 2 chars.
           nextPos = pos + 2;
         } else {
@@ -68,7 +71,7 @@ class CsvParser {
       // If there are no more escape sequences consume the rest of the string.
       if (nextPos === -1) {
         result += string.substr(pos);
-      } else if (pos != nextPos) {
+      } else if (pos !== nextPos) {
         result += string.substring(pos, nextPos);
       }
     }

--- a/logreader.js
+++ b/logreader.js
@@ -248,5 +248,5 @@ LogReader.prototype.processLogLine_ = function(line) {
 
 if (typeof module === 'object' && typeof module.exports === 'object') {
   var CsvParser = require('./csvparser.js')
-  module.exports = LogReader;
+  module.exports = { LogReader, parseString, parseVarArgs }
 } 

--- a/logreader.js
+++ b/logreader.js
@@ -112,7 +112,7 @@ LogReader.prototype.processLogChunk = function(chunk) {
  */
 LogReader.prototype.processLogLine = function(line) {
   if (!this.timedRange_) {
-    this.processLog_([line]);
+    this.processLogLine_(line);
     return;
   }
   if (line.startsWith("current-time")) {
@@ -130,7 +130,7 @@ LogReader.prototype.processLogLine = function(line) {
     if (this.hasSeenTimerMarker_) {
       this.logLinesSinceLastTimerMarker_.push(line);
     } else if (!line.startsWith("tick")) {
-      this.processLog_([line]);
+      this.processLogLine_(line);
     }
   }
 };
@@ -175,6 +175,9 @@ LogReader.prototype.skipDispatch = function(dispatch) {
   return false;
 };
 
+// Parses dummy variable for readability;
+const parseString = 'parse-string';
+const parseVarArgs = 'parse-var-args';
 
 /**
  * Does a dispatch of a log record.
@@ -185,10 +188,8 @@ LogReader.prototype.skipDispatch = function(dispatch) {
 LogReader.prototype.dispatchLogRow_ = function(fields) {
   // Obtain the dispatch.
   var command = fields[0];
-  if (!(command in this.dispatchTable_)) return;
-
   var dispatch = this.dispatchTable_[command];
-
+  if (dispatch === undefined) return;
   if (dispatch === null || this.skipDispatch(dispatch)) {
     return;
   }
@@ -197,14 +198,16 @@ LogReader.prototype.dispatchLogRow_ = function(fields) {
   var parsedFields = [];
   for (var i = 0; i < dispatch.parsers.length; ++i) {
     var parser = dispatch.parsers[i];
-    if (parser === null) {
+    if (parser === parseString) {
       parsedFields.push(fields[1 + i]);
     } else if (typeof parser == 'function') {
       parsedFields.push(parser(fields[1 + i]));
-    } else {
+    } else if (parser === parseVarArgs) {
       // var-args
       parsedFields.push(fields.slice(1 + i));
       break;
+    } else {
+      throw new Error("Invalid log field parser: " + parser);
     }
   }
 
@@ -220,18 +223,27 @@ LogReader.prototype.dispatchLogRow_ = function(fields) {
  * @private
  */
 LogReader.prototype.processLog_ = function(lines) {
-  for (var i = 0, n = lines.length; i < n; ++i, ++this.lineNum_) {
-    var line = lines[i];
-    if (!line) {
-      continue;
-    }
+  for (var i = 0, n = lines.length; i < n; ++i) {
+    this.processLogLine_(lines[i]);
+  }
+}
+
+/**
+ * Processes a single log line.
+ *
+ * @param {String} a log line
+ * @private
+ */
+LogReader.prototype.processLogLine_ = function(line) {
+  if (line.length > 0) {
     try {
       var fields = this.csvParser_.parseLine(line);
       this.dispatchLogRow_(fields);
     } catch (e) {
-      this.printError('line ' + (this.lineNum_ + 1) + ': ' + (e.message || e));
+      this.printError('line ' + (this.lineNum_ + 1) + ': ' + (e.message || e) + '\n' + e.stack);
     }
   }
+  this.lineNum_++;
 };
 
 if (typeof module === 'object' && typeof module.exports === 'object') {


### PR DESCRIPTION
Updated the source files from [the latest checkin to v8](https://github.com/v8/v8/tree/abfdb819ced84d76595083a5c278ad2561d3f516). I made sure to preserve the `module.exports` changes from 90240c6 and 0e179f8.

It looks like this update may need to be a major semVer change. In `logreader.js`, dispatch parsers can no longer specify `null` as a valid parser and the default behavior is to throw an error. A subclass must specify either `'parse-string'` or `'parse-var-args'` (exported as variables) for the previous `null` and default behavior, respectively.

As such, I've changed the the exports of `logreader.js` to no longer be `module.exports = LogReader` but to now be `module.exports = { LogReader, parseString, parseVarArgs }` to accommodate the new constant strings. We could also expose the strings as statics on the LogReader so consumers require statements don't have to change. Up to you!

I don't understand the other modules much, so I can't speak to whether they contain breaking changes.

Cheers!